### PR TITLE
chore: ENG-2459: add LINEAR_APP context to pr-lint jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ workflows:
       - common/pr-lint:
           context:
             - GITHUB
+            - LINEAR_APP
       - lint:
           context:
             - NPM


### PR DESCRIPTION

- Add `LINEAR_APP` to the context list of `common/pr-lint` jobs in all workflows
