### PR TITLE
fix(ci): INF-1825: use orb@3 npm trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   sumologic: circleci/sumologic@1
-  common: timebyping/common@2
+  common: timebyping/common@3
 parameters:
   executor-tag:
     type: string
@@ -97,7 +97,4 @@ workflows:
             - GITHUB
             - NPM
           executor-tag: << pipeline.parameters.executor-tag >>
-          package-manager: yarn
-          dry-run: false
-          github: true
           npm: true


### PR DESCRIPTION
Bump orb to `timebyping/common@3`; drop removed params (`package-manager`, `dry-run`, `github`).

Blocked on `@timebyping/semantic-release-slack-bot` Trusted Publisher on npmjs.com (repo `semantic-release-slack-bot`, workflow `main-branch`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; the main risk is the `common/semantic-release` orb interface change potentially breaking releases if parameters/contexts don’t match expected behavior in v3.
> 
> **Overview**
> Updates CircleCI to use `timebyping/common@3` and removes deprecated `common/semantic-release` parameters (`package-manager`, `dry-run`, `github`), leaving only `npm: true` alongside existing contexts/executor settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f07d20c63fbf1a83f27f9a8c883320fef4ebf56. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->