### PR TITLE
chore(ci): INF-2245: remove SumoLogic orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2.1
 orbs:
-  sumologic: circleci/sumologic@1
   common: timebyping/common@3
 parameters:
   executor-tag:
@@ -51,9 +50,6 @@ workflows:
           - << pipeline.git.branch >>
           - main
     jobs:
-      - sumologic/workflow-collector:
-          context:
-            - SUMOLOGIC
       - common/pr-lint:
           context:
             - GITHUB
@@ -74,9 +70,6 @@ workflows:
         - << pipeline.git.branch >>
         - main
     jobs:
-      - sumologic/workflow-collector:
-          context:
-            - SUMOLOGIC
       - lint:
           context:
             - NPM


### PR DESCRIPTION
[INF-2245](https://linear.app/laurelai/issue/INF-2245/remove-sumologic-circleci-orb-org-wide)

Remove the unused `sumologic` CircleCI orb and its `sumologic/workflow-collector` jobs from `.circleci/config.yml`. SumoLogic is no longer used. Config-only deletion; no job depends on the collector.
